### PR TITLE
Return window object from open method

### DIFF
--- a/winchan.js
+++ b/winchan.js
@@ -211,6 +211,7 @@ var WinChan = (function() {
         addListener(window, 'message', onMessage);
 
         return {
+          originalPopup: w,
           close: cleanup,
           focus: function() {
             if (w) {


### PR DESCRIPTION
Return the window object when opening a new window via `WinChan.open`. This change is needed to directly access the object for the opened popup and e.g. check whether or not the popup was blocked by the browser (`originalPopup === null` or more advanced ways described [here](https://stackoverflow.com/questions/2914/how-can-i-detect-if-a-browser-is-blocking-a-popup)).

@luisrudge 

Ref: https://github.com/auth0/auth0.js/issues/868