### PR TITLE
[master] add type checking for event data

### DIFF
--- a/winchan.js
+++ b/winchan.js
@@ -181,6 +181,7 @@ var WinChan = (function() {
 
         function onMessage(e) {
           if (e.origin !== origin) { return; }
+          if (typeof e.data !== 'string') { return; }
           try {
             var d = JSON.parse(e.data);
           } catch(err) {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The window message event may be used in various libraries and services, and the data sent by them may not be string.
This PR is to add a type checking on e.data before parsing to reduce the chance of winchan try to parse the wrong message and throw out error





